### PR TITLE
Add synthetic dataset and tests for descriptor computation and training

### DIFF
--- a/data/synthetic.csv
+++ b/data/synthetic.csv
@@ -1,0 +1,5 @@
+smiles,length,num_C,label
+C,1,1,3
+CC,2,2,6
+CO,2,1,5
+N,1,0,2

--- a/hlgap/__init__.py
+++ b/hlgap/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal homolumogapforecast utilities."""

--- a/hlgap/descriptors.py
+++ b/hlgap/descriptors.py
@@ -1,0 +1,16 @@
+"""Utilities for computing simple molecular descriptors."""
+from typing import Iterable, List, Dict
+
+def compute_descriptors(smiles_list: Iterable[str]) -> List[Dict[str, int]]:
+    """Compute simple descriptors for each SMILES string.
+
+    The descriptors are intentionally trivial: the length of the SMILES string
+    and the count of carbon atoms ("C" characters).
+    """
+    descriptors = []
+    for smi in smiles_list:
+        descriptors.append({
+            "length": len(smi),
+            "num_C": smi.count("C"),
+        })
+    return descriptors

--- a/hlgap/train.py
+++ b/hlgap/train.py
@@ -1,0 +1,58 @@
+"""Simple training routine using linear regression without external deps."""
+import csv
+from typing import List
+from .descriptors import compute_descriptors
+
+def _det3(m):
+    return (m[0][0]*(m[1][1]*m[2][2] - m[1][2]*m[2][1])
+            - m[0][1]*(m[1][0]*m[2][2] - m[1][2]*m[2][0])
+            + m[0][2]*(m[1][0]*m[2][1] - m[1][1]*m[2][0]))
+
+def _linear_regression(x1: List[float], x2: List[float], y: List[float]):
+    n = len(y)
+    Sx1 = sum(x1)
+    Sx2 = sum(x2)
+    Sy = sum(y)
+    Sx1x1 = sum(a*a for a in x1)
+    Sx2x2 = sum(a*a for a in x2)
+    Sx1x2 = sum(a*b for a, b in zip(x1, x2))
+    Sx1y = sum(a*b for a, b in zip(x1, y))
+    Sx2y = sum(a*b for a, b in zip(x2, y))
+
+    M = [[n, Sx1, Sx2],
+         [Sx1, Sx1x1, Sx1x2],
+         [Sx2, Sx1x2, Sx2x2]]
+    R = [Sy, Sx1y, Sx2y]
+
+    M0 = [[R[0], Sx1, Sx2],
+          [R[1], Sx1x1, Sx1x2],
+          [R[2], Sx1x2, Sx2x2]]
+    M1 = [[n, R[0], Sx2],
+          [Sx1, R[1], Sx1x2],
+          [Sx2, R[2], Sx2x2]]
+    M2 = [[n, Sx1, R[0]],
+          [Sx1, Sx1x1, R[1]],
+          [Sx2, Sx1x2, R[2]]]
+
+    D = _det3(M)
+    if D == 0:
+        raise ValueError("Design matrix is singular")
+    w0 = _det3(M0) / D
+    w1 = _det3(M1) / D
+    w2 = _det3(M2) / D
+    return w0, w1, w2
+
+
+def train(data_path: str) -> List[float]:
+    """Train a linear model on the given dataset and return predictions."""
+    with open(data_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    smiles = [row["smiles"] for row in rows]
+    y = [float(row["label"]) for row in rows]
+    desc = compute_descriptors(smiles)
+    x1 = [d["length"] for d in desc]
+    x2 = [d["num_C"] for d in desc]
+    w0, w1, w2 = _linear_regression(x1, x2, y)
+    preds = [w0 + w1*a + w2*b for a, b in zip(x1, x2)]
+    return preds

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -1,0 +1,17 @@
+import csv
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from hlgap.descriptors import compute_descriptors
+
+def test_compute_descriptors_matches_dataset():
+    data_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'synthetic.csv')
+    with open(data_path, newline='') as f:
+        rows = list(csv.DictReader(f))
+    smiles = [r['smiles'] for r in rows]
+    expected = [
+        {'length': int(r['length']), 'num_C': int(r['num_C'])}
+        for r in rows
+    ]
+    result = compute_descriptors(smiles)
+    assert result == expected

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,15 @@
+import csv
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from hlgap.train import train
+
+def test_training_produces_correct_shape():
+    data_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'synthetic.csv')
+    preds = train(data_path)
+    with open(data_path, newline='') as f:
+        rows = list(csv.DictReader(f))
+    labels = [float(r['label']) for r in rows]
+    assert len(preds) == len(labels)
+    for p, y in zip(preds, labels):
+        assert abs(p - y) < 1e-6


### PR DESCRIPTION
## Summary
- add tiny SMILES dataset with precomputed descriptor values
- implement simple descriptor calculation and linear regression training utilities
- verify descriptor correctness and training behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb3b0726c8329a6f6012fe111ceb7