### PR TITLE
Use RDKit descriptors for HOMO-LUMO gap predictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+combined_dataset.csv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # homolumogapforecast
-a project for teaching basic ai knowledge for Chemist
+
+This project demonstrates how artificial intelligence can be applied to a simple
+chemistry task: predicting the HOMO–LUMO gap of a molecule from its SMILES
+string.  It is intended as an educational example for traditional chemists who
+would like to learn basic AI workflows.
+
+## Workflow
+
+1. **Sampling and preprocessing**
+   - Four CSV files are required: cations, anions, neutral molecules and
+     radicals.  Each file must contain two columns: `smiles` and
+     `HOMO-LUMO Gap(Hartree)`.
+   - Using seed 1000, 100000 molecules are sampled from each dataset.  The four
+     samples are concatenated, shuffled and saved as `combined_dataset.csv`.
+   - RDKit validates the SMILES strings and computes a small set of molecular
+     descriptors (`MolWt`, `MolLogP`, `TPSA`, `NumHDonors`, `NumHAcceptors`).
+2. **Model training**
+   - A Random Forest regressor is trained to predict the HOMO–LUMO gap.
+   - Five-fold cross‑validation is performed with seeds 1000, 2000, 3000,
+     4000 and 5000.
+3. **Descriptor evaluation**
+   - After training, feature importances highlight which descriptors contribute
+     most to the prediction.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python -m src.main cation.csv anion.csv neutral.csv radical.csv
+```
+
+The script prints cross‑validation metrics for each seed and the importance of
+each descriptor.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+scikit-learn
+rdkit-pypi
+joblib

--- a/src/data_preparation.py
+++ b/src/data_preparation.py
@@ -1,0 +1,108 @@
+"""Data preparation utilities for HOMO-LUMO gap prediction."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import pandas as pd
+from rdkit import Chem
+from rdkit.Chem import Descriptors
+
+# Descriptor functions and names used for featurization
+DESCRIPTOR_FUNCS = [
+    ("MolWt", Descriptors.MolWt),
+    ("MolLogP", Descriptors.MolLogP),
+    ("TPSA", Descriptors.TPSA),
+    ("NumHDonors", Descriptors.NumHDonors),
+    ("NumHAcceptors", Descriptors.NumHAcceptors),
+]
+DESCRIPTOR_NAMES = [name for name, _ in DESCRIPTOR_FUNCS]
+
+
+def load_and_sample(paths: Iterable[Path | str], n_samples: int = 100_000, seed: int = 1000) -> pd.DataFrame:
+    """Load CSV files and randomly sample ``n_samples`` rows from each.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of CSV file paths. Each file should contain ``smiles`` and
+        ``HOMO-LUMO Gap(Hartree)`` columns.
+    n_samples:
+        Number of rows to sample from each CSV.
+    seed:
+        Random seed used for sampling and shuffling.
+
+    Returns
+    -------
+    pd.DataFrame
+        A shuffled DataFrame combining samples from all provided files.
+    """
+    frames: List[pd.DataFrame] = []
+    for path in paths:
+        df = pd.read_csv(path)
+        if len(df) < n_samples:
+            raise ValueError(f"File {path} contains fewer than {n_samples} rows")
+        frames.append(df.sample(n=n_samples, random_state=seed))
+
+    combined = (
+        pd.concat(frames, ignore_index=True)
+        .sample(frac=1.0, random_state=seed)
+        .reset_index(drop=True)
+    )
+    return combined
+
+
+def compute_descriptors(mol: Chem.Mol) -> np.ndarray:
+    """Compute RDKit molecular descriptors for a molecule."""
+    return np.array([func(mol) for _, func in DESCRIPTOR_FUNCS], dtype=float)
+
+
+def featurize(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray, List[str]]:
+    """Convert SMILES strings to molecular descriptor vectors.
+
+    Invalid SMILES strings are skipped.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing ``smiles`` and ``HOMO-LUMO Gap(Hartree)`` columns.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, List[str]]
+        Feature matrix ``X`` of shape ``(n_samples, len(DESCRIPTOR_NAMES))``,
+        target vector ``y`` and a list of valid SMILES strings.
+    """
+    features: List[np.ndarray] = []
+    gaps: List[float] = []
+    valid_smiles: List[str] = []
+
+    for smiles, gap in zip(df["smiles"], df["HOMO-LUMO Gap(Hartree)"]):
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            continue
+        arr = compute_descriptors(mol)
+        features.append(arr)
+        gaps.append(gap)
+        valid_smiles.append(smiles)
+
+    X = np.stack(features)
+    y = np.array(gaps, dtype=float)
+    return X, y, valid_smiles
+
+
+def prepare_dataset(paths: Iterable[Path | str], n_samples: int = 100_000, seed: int = 1000) -> Tuple[np.ndarray, np.ndarray, List[str]]:
+    """High-level convenience function returning features and targets."""
+    df = load_and_sample(paths, n_samples=n_samples, seed=seed)
+    X, y, smiles = featurize(df)
+    return X, y, smiles
+
+
+__all__ = [
+    "load_and_sample",
+    "compute_descriptors",
+    "featurize",
+    "prepare_dataset",
+    "DESCRIPTOR_NAMES",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,60 @@
+"""Command line interface for HOMO-LUMO gap prediction project."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from data_preparation import DESCRIPTOR_NAMES, featurize, load_and_sample
+from model_training import cross_validate, feature_importance, summarize_results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HOMO-LUMO gap prediction")
+    parser.add_argument("cation", type=Path, help="CSV file with cation molecules")
+    parser.add_argument("anion", type=Path, help="CSV file with anion molecules")
+    parser.add_argument("neutral", type=Path, help="CSV file with neutral molecules")
+    parser.add_argument("radical", type=Path, help="CSV file with radical molecules")
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=100_000,
+        help="Number of samples to draw from each CSV",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("combined_dataset.csv"),
+        help="Where to save the combined sampled dataset",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    csv_paths = [args.cation, args.anion, args.neutral, args.radical]
+
+    # Step 1: load and sample data
+    combined = load_and_sample(csv_paths, n_samples=args.sample_size, seed=1000)
+    combined.to_csv(args.output, index=False)
+
+    # Step 2: featurize
+    X, y, smiles = featurize(combined)
+    print(f"Generated features for {len(smiles)} molecules")
+
+    # Step 3: model training with cross-validation
+    seeds = [1000, 2000, 3000, 4000, 5000]
+    results = cross_validate(X, y, seeds=seeds, n_splits=5)
+    summarize_results(results)
+
+    # Step 4: evaluate feature importance on full dataset
+    importances = feature_importance(X, y, DESCRIPTOR_NAMES, seed=1000)
+    sorted_imps = sorted(importances.items(), key=lambda x: x[1], reverse=True)
+    print("Descriptor importances:")
+    for name, val in sorted_imps:
+        print(f"  {name}: {val:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model_training.py
+++ b/src/model_training.py
@@ -1,0 +1,81 @@
+"""Model training and evaluation utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+import numpy as np
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import KFold
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class FoldMetrics:
+    rmse: float
+    mae: float
+    r2: float
+
+
+def cross_validate(
+    X: np.ndarray,
+    y: np.ndarray,
+    seeds: Iterable[int] = (1000, 2000, 3000, 4000, 5000),
+    n_splits: int = 5,
+) -> Dict[int, List[FoldMetrics]]:
+    """Perform K-fold cross-validation for multiple random seeds."""
+    results: Dict[int, List[FoldMetrics]] = {}
+
+    for seed in seeds:
+        kf = KFold(n_splits=n_splits, shuffle=True, random_state=seed)
+        metrics: List[FoldMetrics] = []
+        for train_idx, test_idx in kf.split(X):
+            scaler = StandardScaler()
+            X_train = scaler.fit_transform(X[train_idx])
+            X_test = scaler.transform(X[test_idx])
+            model = RandomForestRegressor(
+                n_estimators=100,
+                random_state=seed,
+                n_jobs=-1,
+            )
+            model.fit(X_train, y[train_idx])
+            preds = model.predict(X_test)
+            metrics.append(
+                FoldMetrics(
+                    rmse=mean_squared_error(y[test_idx], preds, squared=False),
+                    mae=mean_absolute_error(y[test_idx], preds),
+                    r2=r2_score(y[test_idx], preds),
+                )
+            )
+        results[seed] = metrics
+    return results
+
+
+def summarize_results(results: Dict[int, List[FoldMetrics]]) -> None:
+    """Print averaged metrics for each seed."""
+    for seed, folds in results.items():
+        rmse = np.mean([f.rmse for f in folds])
+        mae = np.mean([f.mae for f in folds])
+        r2 = np.mean([f.r2 for f in folds])
+        print(f"Seed {seed}: RMSE={rmse:.4f}, MAE={mae:.4f}, R2={r2:.4f}")
+
+
+def feature_importance(
+    X: np.ndarray, y: np.ndarray, descriptor_names: Sequence[str], seed: int = 1000
+) -> Dict[str, float]:
+    """Train a random forest model and return feature importances mapped to descriptors."""
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    model = RandomForestRegressor(n_estimators=100, random_state=seed, n_jobs=-1)
+    model.fit(X_scaled, y)
+    importances = model.feature_importances_
+    return {name: imp for name, imp in zip(descriptor_names, importances)}
+
+
+__all__ = [
+    "FoldMetrics",
+    "cross_validate",
+    "summarize_results",
+    "feature_importance",
+]

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+from rdkit import Chem
+
+# Make src modules importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from data_preparation import DESCRIPTOR_NAMES, compute_descriptors
+from model_training import cross_validate
+
+
+def test_compute_descriptors_ethanol():
+    mol = Chem.MolFromSmiles('CCO')
+    desc = compute_descriptors(mol)
+    from rdkit.Chem import Descriptors
+    expected = np.array([
+        Descriptors.MolWt(mol),
+        Descriptors.MolLogP(mol),
+        Descriptors.TPSA(mol),
+        Descriptors.NumHDonors(mol),
+        Descriptors.NumHAcceptors(mol),
+    ])
+    assert np.allclose(desc, expected)
+    assert list(DESCRIPTOR_NAMES) == ['MolWt', 'MolLogP', 'TPSA', 'NumHDonors', 'NumHAcceptors']
+
+
+def test_cross_validate_runs():
+    smiles = ['CC', 'CCC', 'CCCC', 'CCO']
+    y = np.array([0.1, 0.2, 0.3, 0.4])
+    X = []
+    for s in smiles:
+        mol = Chem.MolFromSmiles(s)
+        X.append(compute_descriptors(mol))
+    X = np.array(X)
+    results = cross_validate(X, y, seeds=[1000], n_splits=2)
+    assert 1000 in results
+    assert len(results[1000]) == 2


### PR DESCRIPTION
## Summary
- replace Morgan fingerprints with RDKit molecular descriptors
- scale descriptor features during training and report importances by name
- document descriptor-based workflow and add basic tests

## Testing
- `python -m py_compile src/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68beadaf6e108329a0cca7ffd9d57890