### PR TITLE
Use RDKit descriptors for featurization

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import argparse
 from pathlib import Path
 
 import numpy as np
+from rdkit.Chem import Descriptors
 
 from data_preparation import load_and_sample, featurize
 from model_training import cross_validate, feature_importance, summarize_results
@@ -41,6 +42,30 @@ def main() -> None:
 
     # Step 2: featurize
     X, y, smiles = featurize(combined)
+    excluded = {
+        "BalabanJ",
+        "BertzCT",
+        "Chi0",
+        "Chi0n",
+        "Chi0v",
+        "Chi1",
+        "Chi1n",
+        "Chi1v",
+        "Chi2n",
+        "Chi2v",
+        "Chi3n",
+        "Chi3v",
+        "Chi4n",
+        "Chi4v",
+        "HallKierAlpha",
+        "Ipc",
+        "Kappa1",
+        "Kappa2",
+        "Kappa3",
+    }
+    descriptor_names = [
+        name for name, _ in Descriptors._descList if "EState" not in name and name not in excluded
+    ]
     print(f"Generated features for {len(smiles)} molecules")
 
     # Step 3: model training with cross-validation
@@ -51,9 +76,10 @@ def main() -> None:
     # Step 4: evaluate feature importance on full dataset
     importances = feature_importance(X, y, seed=1000)
     top_idx = np.argsort(importances)[::-1][:10]
-    print("Top 10 fingerprint bits by importance:")
+    print("Top 10 descriptors by importance:")
     for idx in top_idx:
-        print(f"  fp{idx}: {importances[idx]:.4f}")
+        name = descriptor_names[idx] if idx < len(descriptor_names) else str(idx)
+        print(f"  {name}: {importances[idx]:.4f}")
 
 
 if __name__ == "__main__":

--- a/tests/test_featurize_descriptors.py
+++ b/tests/test_featurize_descriptors.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import numpy as np
+import pandas as pd
+from rdkit.Chem import Descriptors
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+from data_preparation import featurize
+
+def test_featurize_returns_rdkit_descriptors():
+    df = pd.DataFrame({
+        'smiles': ['CC', 'O'],
+        'HOMO-LUMO Gap(Hartree)': [0.1, 0.2],
+    })
+    X, y, smiles = featurize(df)
+    excluded = {
+        "BalabanJ",
+        "BertzCT",
+        "Chi0",
+        "Chi0n",
+        "Chi0v",
+        "Chi1",
+        "Chi1n",
+        "Chi1v",
+        "Chi2n",
+        "Chi2v",
+        "Chi3n",
+        "Chi3v",
+        "Chi4n",
+        "Chi4v",
+        "HallKierAlpha",
+        "Ipc",
+        "Kappa1",
+        "Kappa2",
+        "Kappa3",
+    }
+    n_desc = len([d for d in Descriptors._descList if "EState" not in d[0] and d[0] not in excluded])
+    assert X.shape == (2, n_desc)
+    assert np.allclose(y, [0.1, 0.2])
+    assert smiles == ['CC', 'O']


### PR DESCRIPTION
## Summary
- Replace Morgan fingerprints with RDKit molecular descriptors, excluding unstable EState and graph descriptors
- Update CLI to report descriptor importance by name
- Add tests ensuring descriptor-based featurization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beca43a9ac83299bcacc949c00eef0